### PR TITLE
Reduce the printing time by a 20% (down to 25 minutes)

### DIFF
--- a/Descriptors.c
+++ b/Descriptors.c
@@ -141,7 +141,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor = {
 			.Attributes             = (EP_TYPE_INTERRUPT | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
 			.EndpointSize           = JOYSTICK_EPSIZE,
 			.PollingIntervalMS      = POLLING_MS
-		},
+		}
 };
 
 // Language Descriptor Structure

--- a/Descriptors.c
+++ b/Descriptors.c
@@ -130,7 +130,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor = {
 			.EndpointAddress        = JOYSTICK_IN_EPADDR,
 			.Attributes             = (EP_TYPE_INTERRUPT | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
 			.EndpointSize           = JOYSTICK_EPSIZE,
-			.PollingIntervalMS      = 0x05
+			.PollingIntervalMS      = POLLING_MS
 		},
 
 	.HID_ReportOUTEndpoint =
@@ -140,7 +140,7 @@ const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor = {
 			.EndpointAddress        = JOYSTICK_OUT_EPADDR,
 			.Attributes             = (EP_TYPE_INTERRUPT | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
 			.EndpointSize           = JOYSTICK_EPSIZE,
-			.PollingIntervalMS      = 0x05
+			.PollingIntervalMS      = POLLING_MS
 		},
 };
 

--- a/Descriptors.h
+++ b/Descriptors.h
@@ -45,6 +45,8 @@ enum StringDescriptors_t
 #define DTYPE_HID                 0x21
 // Descriptor Header Type - HID Class HID Report Descriptor
 #define DTYPE_Report              0x22
+// Joystick endpoint polling interval (in ms). It looks like any value set here renders in a timing multiple of 8 ms.
+#define POLLING_MS 8
 
 // Function Prototypes
 uint16_t CALLBACK_USB_GetDescriptor(

--- a/Joystick.c
+++ b/Joystick.c
@@ -12,7 +12,7 @@ Nintendo Switch. This also works to a limited degree on the PS3.
 
 Since System Update v3.0.0, the Nintendo Switch recognizes the Pokken
 Tournament Pro Pad as a Pro Controller. Physical design limitations prevent
-the Pokken Controller from functioning at the same level as the Pro
+the Pokken Controller from functioning at zhe same level as the Pro
 Controller. However, by default most of the descriptors are there, with the
 exception of Home and Capture. Descriptor modification allows us to unlock
 these buttons for our use.
@@ -29,7 +29,8 @@ these buttons for our use.
 extern const uint8_t image_data[0x12c1] PROGMEM;
 
 // Main entry point.
-int main(void) {
+int main(void)
+{
 	// We'll start by performing hardware and peripheral setup.
 	SetupHardware();
 	// We'll then enable global interrupts for our use.
@@ -45,41 +46,46 @@ int main(void) {
 }
 
 // Configures hardware and peripherals, such as the USB peripherals.
-void SetupHardware(void) {
+void SetupHardware(void)
+{
 	// We need to disable watchdog if enabled by bootloader/fuses.
 	MCUSR &= ~(1 << WDRF);
 	wdt_disable();
 
 	// We need to disable clock division before initializing the USB hardware.
 	clock_prescale_set(clock_div_1);
+
 	// We can then initialize our hardware and peripherals, including the USB stack.
 
-	#ifdef ALERT_WHEN_DONE
+#ifdef ALERT_WHEN_DONE
 	// Both PORTD and PORTB will be used for the optional LED flashing and buzzer.
-	#warning LED and Buzzer functionality enabled. All pins on both PORTB and \
-PORTD will toggle when printing is done.
-	DDRD  = 0xFF; //Teensy uses PORTD
-	PORTD =  0x0;
-                  //We'll just flash all pins on both ports since the UNO R3
-	DDRB  = 0xFF; //uses PORTB. Micro can use either or, but both give us 2 LEDs
-	PORTB =  0x0; //The ATmega328P on the UNO will be resetting, so unplug it?
-	#endif
+#warning LED and Buzzer functionality enabled. All pins on both PORTB and PORTD will toggle when printing is done.
+	DDRD = 0xFF; //Teensy uses PORTD
+	PORTD = 0x0;
+	//We'll just flash all pins on both ports since the UNO R3
+	DDRB = 0xFF; //uses PORTB. Micro can use either or, but both give us 2 LEDs
+	PORTB = 0x0; //The ATmega328P on the UNO will be resetting, so unplug it?
+#endif
+
 	// The USB stack should be initialized last.
 	USB_Init();
 }
 
 // Fired to indicate that the device is enumerating.
-void EVENT_USB_Device_Connect(void) {
+void EVENT_USB_Device_Connect(void)
+{
 	// We can indicate that we're enumerating here (via status LEDs, sound, etc.).
 }
 
 // Fired to indicate that the device is no longer connected to a host.
-void EVENT_USB_Device_Disconnect(void) {
+void EVENT_USB_Device_Disconnect(void)
+{
 	// We can indicate that our device is not ready (via status LEDs, sound, etc.).
 }
 
 // Fired when the host set the current configuration of the USB device after enumeration.
-void EVENT_USB_Device_ConfigurationChanged(void) {
+void EVENT_USB_Device_ConfigurationChanged(void)
+{
 	bool ConfigSuccess = true;
 
 	// We setup the HID report endpoints.
@@ -90,14 +96,16 @@ void EVENT_USB_Device_ConfigurationChanged(void) {
 }
 
 // Process control requests sent to the device from the USB host.
-void EVENT_USB_Device_ControlRequest(void) {
+void EVENT_USB_Device_ControlRequest(void)
+{
 	// We can handle two control requests: a GetReport and a SetReport.
 
 	// Not used here, it looks like we don't receive control request from the Switch.
 }
 
 // Process and deliver data from IN and OUT endpoints.
-void HID_Task(void) {
+void HID_Task(void)
+{
 	// If the device isn't connected and properly configured, we can't do anything here.
 	if (USB_DeviceState != DEVICE_STATE_Configured)
 		return;
@@ -113,7 +121,7 @@ void HID_Task(void) {
 			// We'll create a place to store our data received from the host.
 			USB_JoystickReport_Output_t JoystickOutputData;
 			// We'll then take in that data, setting it up in our storage.
-			while(Endpoint_Read_Stream_LE(&JoystickOutputData, sizeof(JoystickOutputData), NULL) != ENDPOINT_RWSTREAM_NoError);
+			while (Endpoint_Read_Stream_LE(&JoystickOutputData, sizeof(JoystickOutputData), NULL) != ENDPOINT_RWSTREAM_NoError);
 			// At this point, we can react to this data.
 
 			// However, since we're not doing anything with this data, we abandon it.
@@ -132,7 +140,7 @@ void HID_Task(void) {
 		// We'll then populate this report with what we want to send to the host.
 		GetNextReport(&JoystickInputData);
 		// Once populated, we can output this data to the host. We do this by first writing the data to the control stream.
-		while(Endpoint_Write_Stream_LE(&JoystickInputData, sizeof(JoystickInputData), NULL) != ENDPOINT_RWSTREAM_NoError);
+		while (Endpoint_Write_Stream_LE(&JoystickInputData, sizeof(JoystickInputData), NULL) != ENDPOINT_RWSTREAM_NoError);
 		// We then send an IN packet on this endpoint.
 		Endpoint_ClearIN();
 	}
@@ -141,10 +149,8 @@ void HID_Task(void) {
 typedef enum {
 	SYNC_CONTROLLER,
 	SYNC_POSITION,
-	STOP_X,
-	STOP_Y,
-	MOVE_X,
-	MOVE_Y,
+	MOVE,
+	STOP,
 	DONE
 } State_t;
 State_t state = SYNC_CONTROLLER;
@@ -153,13 +159,16 @@ State_t state = SYNC_CONTROLLER;
 int echoes = 0;
 USB_JoystickReport_Input_t last_report;
 
-int report_count = 0;
+int command_count = 0;
 int xpos = 0;
 int ypos = 0;
 int portsval = 0;
 
-// Prepare the next report for the host.
-void GetNextReport(USB_JoystickReport_Input_t* const ReportData) {
+#define ms_2_count(ms) (ms / ECHOES / (POLLING_MS / 8 * 8))
+
+// Prepare the next report for the host
+void GetNextReport(USB_JoystickReport_Input_t *const ReportData)
+{
 
 	// Prepare an empty report
 	memset(ReportData, 0, sizeof(USB_JoystickReport_Input_t));
@@ -180,90 +189,81 @@ void GetNextReport(USB_JoystickReport_Input_t* const ReportData) {
 	// States and moves management
 	switch (state)
 	{
-		case SYNC_CONTROLLER:
-			if (report_count > 100)
-			{
-				report_count = 0;
-				state = SYNC_POSITION;
-			}
-			else if (report_count == 25 || report_count == 50)
-			{
+	case SYNC_CONTROLLER:
+		if (command_count > ms_2_count(2000))
+		{
+			command_count = 0;
+			state = SYNC_POSITION;
+		}	
+		else
+		{
+			if (command_count == ms_2_count(500) || command_count == ms_2_count(1000))
 				ReportData->Button |= SWITCH_L | SWITCH_R;
-			}
-			else if (report_count == 75 || report_count == 100)
-			{
+			else if (command_count == ms_2_count(1500) || command_count == ms_2_count(2000))
 				ReportData->Button |= SWITCH_A;
-			}
-			report_count++;
-			break;
-		case SYNC_POSITION:
-			if (report_count == 250)
-			{
-				report_count = 0;
-				xpos = 0;
-				ypos = 0;
-				state = STOP_X;
-			}
-			else
-			{
-				// Moving faster with LX/LY
-				ReportData->LX = STICK_MIN;
-				ReportData->LY = STICK_MIN;
-			}
-			if (report_count == 75 || report_count == 150)
-			{
-				// Clear the screen
+			command_count++;
+		}
+		break;
+	case SYNC_POSITION:
+		if (command_count > ms_2_count(5000))
+		{
+			command_count = 0;
+			xpos = 0;
+			ypos = 0;
+			state = STOP;
+		}
+		else
+		{
+			// Moving faster with LX/LY
+			ReportData->LX = STICK_MIN;
+			ReportData->LY = STICK_MIN;
+			// Clear the screen
+			if (command_count == ms_2_count(2000) || command_count == ms_2_count(4000))
 				ReportData->Button |= SWITCH_MINUS;
-			}
-			report_count++;
-			break;
-		case STOP_X:
-			state = MOVE_X;
-			break;
-		case STOP_Y:
-			if (ypos < 120 - 1)
-				state = MOVE_Y;
-			else
-				state = DONE;
-			break;
-		case MOVE_X:
-			if (ypos % 2)
-			{
-				ReportData->HAT = HAT_LEFT;
-				xpos--;
-			}
-			else
-			{
-				ReportData->HAT = HAT_RIGHT;
-				xpos++;
-			}
-			if (xpos > 0 && xpos < 320 - 1)
-				state = STOP_X;
-			else
-				state = STOP_Y;
-			break;
-		case MOVE_Y:
+			command_count++;
+		}
+		break;
+	case MOVE:
+		if (xpos == 0 && ypos % 2 == 1 || xpos == 319 && ypos % 2 == 0)
 			ReportData->HAT = HAT_BOTTOM;
-			ypos++;
-			state = STOP_X;
-			break;
-		case DONE:
-			#ifdef ALERT_WHEN_DONE
-			portsval = ~portsval;
-			PORTD = portsval; //flash LED(s) and sound buzzer if attached
-			PORTB = portsval;
-			_delay_ms(250);
-			#endif
-			return;
+		else if (ypos % 2 == 0)
+			ReportData->HAT = HAT_RIGHT;
+		else
+			ReportData->HAT = HAT_LEFT;
+		state = STOP;
+		break;
+	case STOP:
+		state = MOVE;
+		break;
+	case DONE:
+#ifdef ALERT_WHEN_DONE
+		portsval = ~portsval;
+		PORTD = portsval; // flash LED(s) and sound buzzer if attached
+		PORTB = portsval;
+		_delay_ms(250);
+#endif
+		return;
 	}
 
+	// Position update
+	if (ReportData->HAT == HAT_TOP_RIGHT || ReportData->HAT == HAT_RIGHT || ReportData->HAT == HAT_BOTTOM_RIGHT)
+		xpos++;
+	if (ReportData->HAT == HAT_BOTTOM_LEFT || ReportData->HAT == HAT_LEFT || ReportData->HAT == HAT_TOP_LEFT)
+		xpos--;
+	if (ReportData->HAT == HAT_TOP_LEFT || ReportData->HAT == HAT_TOP || ReportData->HAT == HAT_TOP_RIGHT)
+		ypos--;
+	if (ReportData->HAT == HAT_BOTTOM_RIGHT || ReportData->HAT == HAT_BOTTOM || ReportData->HAT == HAT_BOTTOM_LEFT)
+		ypos++;
+	if (ypos > 119)
+		state = DONE;
+
 	// Inking
-	if (state != SYNC_CONTROLLER && state != SYNC_POSITION)
-		if (pgm_read_byte(&(image_data[(xpos / 8) + (ypos * 40)])) & 1 << (xpos % 8))
-			ReportData->Button |= SWITCH_A;
+	if (state != SYNC_CONTROLLER && state != SYNC_POSITION && state != DONE)
+		if (xpos >= 0 && xpos <= 319 && ypos >= 0 && ypos <= 119)
+			if (pgm_read_byte(&(image_data[(xpos / 8) + (ypos * 40)])) & 1 << (xpos % 8))
+				ReportData->Button |= SWITCH_A;
 
 	// Prepare to echo this report
 	memcpy(&last_report, ReportData, sizeof(USB_JoystickReport_Input_t));
 	echoes = ECHOES;
-
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For my own personal use, I repurposed Switch-Fightstick to output a set sequence
 #### Printing Procedure
 Just press L to select the pixel pen and plug in the controller: it will automatically sync with the console, reset the cursor position, clean the canvas and print. In case you see issues with controller conflicts while in docked mode, try using a USB-C to USB-A adapter in handheld mode. In dock mode, changes in the HDMI connection will briefly make the Switch not respond to incoming USB commands, skipping pixels in the printout. These changes may include turning off the TV, or switching the HDMI input. (Switching to the internal tuner will be OK, if this doesn't trigger a change in the HDMI input.)
 
-Each line is printed top to bottom, alternating from left to right and viceversa. Printing currently takes about half an hour.
+The printing goes from top to bottom, alternating between two lines, from left to right and viceversa. Printing currently takes about 25 minutes.
 
 Optionally, upon completion, the Teensy's LED will begin flashing. On compatible Arduino boards, some combination of the onboard LEDs will flash. On the UNO, for instance, both TX and RX LEDs will flash, however the other LEDs will not. If this functionality is desired, issue `make with-alert` when building the firmware. All pins on both PORTB and PORTD are toggled! Beware of possible interactions with any attached peripherals, say from another project.
 


### PR DESCRIPTION
- Refactored the position updates and state management, to simplify the development of new printing patterns
- Added a zig-zag printing pattern that avoid issuing stop commands (well only one every two lines remains)
- We can print a line with 321 commands (vs the previous 640), but now we need to send 5 USB request per command (vs the previous 3), to avoid pixel skipping
- The overall printing time per pixel went down to 40 ms, from 48 ms