### PR TITLE
Correct typographical errors in `Joystick.c`

### DIFF
--- a/Joystick.c
+++ b/Joystick.c
@@ -12,7 +12,7 @@ Nintendo Switch. This also works to a limited degree on the PS3.
 
 Since System Update v3.0.0, the Nintendo Switch recognizes the Pokken
 Tournament Pro Pad as a Pro Controller. Physical design limitations prevent
-the Pokken Controller from functioning at zhe same level as the Pro
+the Pokken Controller from functioning at the same level as the Pro
 Controller. However, by default most of the descriptors are there, with the
 exception of Home and Capture. Descriptor modification allows us to unlock
 these buttons for our use.
@@ -159,7 +159,7 @@ State_t state = SYNC_CONTROLLER;
 
 // Repeat ECHOES times the last sent report.
 //
-// This is value is affected by several factors:
+// This value is affected by several factors:
 // - The descriptors *.PollingIntervalMS value.
 // - The Switch readiness to accept reports (driven by the Endpoint_IsINReady() function,
 //   it looks to be 8 ms).
@@ -191,7 +191,7 @@ int portsval = 0;
 
 bool complete_zig_zag_pattern(USB_JoystickReport_Input_t *const ReportData, uint8_t move)
 {
-	// This function move the dot, switching between two consecutive lines, following
+	// This function moves the dot, switching between two consecutive lines, following
 	// the move pattern below while moving to the right:
 	//
 	//    3  4 ... N-5  N-4  N-2

--- a/Joystick.c
+++ b/Joystick.c
@@ -256,7 +256,7 @@ void GetNextReport(USB_JoystickReport_Input_t *const ReportData)
 		{
 			command_count = 0;
 			state = SYNC_POSITION;
-		}	
+		}
 		else
 		{
 			if (command_count == ms_2_count(500) || command_count == ms_2_count(1000))
@@ -298,7 +298,7 @@ void GetNextReport(USB_JoystickReport_Input_t *const ReportData)
 			state = ZIG_ZAG_RIGHT;
 		break;
 	case MOVE:
-		if (xpos == 0 && ypos % 2 == 1 || xpos == 319 && ypos % 2 == 0)
+		if ((xpos == 0 && ypos % 2 == 1) || (xpos == 319 && ypos % 2 == 0))
 			ReportData->HAT = HAT_BOTTOM;
 		else if (ypos % 2 == 0)
 			ReportData->HAT = HAT_RIGHT;
@@ -328,14 +328,17 @@ void GetNextReport(USB_JoystickReport_Input_t *const ReportData)
 		ypos--;
 	if (ReportData->HAT == HAT_BOTTOM_RIGHT || ReportData->HAT == HAT_BOTTOM || ReportData->HAT == HAT_BOTTOM_LEFT)
 		ypos++;
-	if (ypos > 119)
-		state = DONE;
 
 	// Inking
 	if (state != SYNC_CONTROLLER && state != SYNC_POSITION && state != DONE)
+	{
 		if (xpos >= 0 && xpos <= 319 && ypos >= 0 && ypos <= 119)
+		{
 			if (pgm_read_byte(&(image_data[(xpos / 8) + (ypos * 40)])) & 1 << (xpos % 8))
 				ReportData->Button |= SWITCH_A;
+		}
+		else (state = DONE);
+	}
 
 	// Prepare to echo this report
 	memcpy(&last_report, ReportData, sizeof(USB_JoystickReport_Input_t));


### PR DESCRIPTION
Also the test on `Joystick.c` ln331 appears to be redundant with the one on ln336. Testing to see if an else to ln336 is feasible.